### PR TITLE
Fix login bug

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -6,7 +6,6 @@ import { useState, useEffect, useRef } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import * as z from "zod";
-import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -35,8 +34,6 @@ export default function SignIn() {
   const [attemptsRemaining, setAttemptsRemaining] = useState<number | null>(null);
   const [secondsLeft, setSecondsLeft] = useState<number | null>(null);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const router = useRouter();
-
   useEffect(() => {
     return () => {
       if (intervalRef.current) clearInterval(intervalRef.current);
@@ -96,9 +93,9 @@ export default function SignIn() {
         throw new Error(errorData.error || "Invalid email or password");
       }
 
-      // Success! Redirect to dashboard
-      router.push("/dashboard");
-      router.refresh(); // Refresh to ensure middleware detects the new cookie
+      // Success! Hard-navigate to dashboard so the browser sends the new cookie
+      // in a fresh HTTP request — avoids a race between router.push and router.refresh.
+      window.location.href = "/dashboard";
     } catch (err) {
       if (err instanceof Error) {
         console.log(err);


### PR DESCRIPTION
Closes #67 

The root cause was a race condition between router.push and router.refresh() — on a device with no      
  Next.js cache, the refresh would win and leave the user on the login page with their cookie set but no
  redirect. window.location.href does a full page load, which sidesteps the issue entirely: the browser sends the   new cookie to the server, middleware validates it, and DashboardRedirect sends them to the right role-specific   dashboard.